### PR TITLE
feat: add question attempt history

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Queue from './pages/Queue';
 import Account from './pages/Account';
 import DevPanel from './pages/DevPanel';
 import Questions from './pages/Questions';
+import History from './pages/History';
 import Session from './pages/Session';
 
 const App = () => {
@@ -67,6 +68,15 @@ const App = () => {
         element={
           <ProtectedRoute>
             <Questions />
+          </ProtectedRoute>
+        }
+      />
+
+      <Route
+        path="/history"
+        element={
+          <ProtectedRoute>
+            <History />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/components/MatchingSetup.tsx
+++ b/frontend/src/components/MatchingSetup.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useAppStore, Difficulty } from '@/store/useAppStore';
 import { topics, languages } from '@/lib/mockData';
-import { Code2, LogOut, CheckCircle2, Shield, BookOpen } from 'lucide-react';
+import { Code2, LogOut, CheckCircle2, Shield, BookOpen, Clock} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { DIFFICULTIES } from '../../../shared/constants';
@@ -82,6 +82,13 @@ export const MatchingSetup = () => {
                 <span className="text-sm font-medium text-primary">Questions</span>
               </button>
             )}
+            <button
+              onClick={() => navigate('/history')}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-primary/10 border border-primary/20 hover:bg-primary/20 hover:border-primary/40 transition-all duration-200"
+            >
+              <Clock className="h-4 w-4 text-primary" />
+              <span className="text-sm font-medium text-primary">History</span>
+            </button>
             <span
               className="text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
               onClick={() => navigate('/account')}

--- a/frontend/src/components/MatchingSetup.tsx
+++ b/frontend/src/components/MatchingSetup.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { useAppStore, Difficulty } from '@/store/useAppStore';
 import { topics, languages } from '@/lib/mockData';
-import { Code2, LogOut, CheckCircle2, Shield, BookOpen, Clock} from 'lucide-react';
+import { Code2, LogOut, CheckCircle2, Shield, BookOpen, Clock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { DIFFICULTIES } from '../../../shared/constants';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,8 +1,10 @@
 const USER_BASE_URL = import.meta.env.VITE_USER_SERVICE_URL;
 const QUESTION_BANK_URL = import.meta.env.VITE_QUESTION_SERVICE_URL;
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 
 export const USER_ENDPOINTS = {
   getProfile: `${USER_BASE_URL}/users/profile`,
+  getNameById: (userId: string) => `${USER_BASE_URL}/users/profile/${userId}`,
   requestAdmin: (userId: string) => `${USER_BASE_URL}/users/${userId}/admin-request`,
   requestDemote: (userId: string) => `${USER_BASE_URL}/users/${userId}/demote-request`,
   health: `${USER_BASE_URL}/users/health`,
@@ -18,8 +20,12 @@ export const USER_ENDPOINTS = {
 export const QUESTION_ENDPOINTS = {
   health: `${QUESTION_BANK_URL}/health`,
   getAllQuestions: `${QUESTION_BANK_URL}/questions`,
-  getRandomQuestion: `${QUESTION_BANK_URL}/questions/random`,
+  getQuestionById: (questionId: string) => `${QUESTION_BANK_URL}/questions/${questionId}`,
   addQuestion: `${QUESTION_BANK_URL}/questions/add`,
   updateQuestion: (questionId: string) => `${QUESTION_BANK_URL}/questions/${questionId}/update`,
   deleteQuestion: (questionId: string) => `${QUESTION_BANK_URL}/questions/${questionId}/delete`,
 };
+
+export const SUPABASE_ENDPOINTS = {
+  getHistory: (userId: string) => `${SUPABASE_URL}/rest/v1/history?user_id=eq.${userId}&order=created_at.desc`,
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,5 +27,6 @@ export const QUESTION_ENDPOINTS = {
 };
 
 export const SUPABASE_ENDPOINTS = {
-  getHistory: (userId: string) => `${SUPABASE_URL}/rest/v1/history?user_id=eq.${userId}&order=created_at.desc`,
-}
+  getHistory: (userId: string) =>
+    `${SUPABASE_URL}/rest/v1/history?user_id=eq.${userId}&order=created_at.desc`,
+};

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -8,304 +8,304 @@ import { supabase } from '@/lib/supabase';
 import { USER_ENDPOINTS, QUESTION_ENDPOINTS, SUPABASE_ENDPOINTS } from '@/lib/api';
 
 interface HistoryEntry {
-    id: string;
-    question_id: string;
-    session_id: string;
-    created_at: string;
-    solution?: string;
-    question_title: string;
-    question_description: string;
-    question_difficulty: 'easy' | 'medium' | 'hard';
-    question_topic: string[];
-    peer_username?: string;
+	id: string;
+	question_id: string;
+	session_id: string;
+	created_at: string;
+	solution?: string;
+	question_title: string;
+	question_description: string;
+	question_difficulty: 'easy' | 'medium' | 'hard';
+	question_topic: string[];
+	peer_username?: string;
 }
 
 const topicColors: Record<string, string> = {
-    arrays_and_hashing: 'text-blue-500 border-blue-500/30 bg-blue-500/10',
-    two_pointers: 'text-cyan-500 border-cyan-500/30 bg-cyan-500/10',
-    stack: 'text-violet-500 border-violet-500/30 bg-violet-500/10',
-    binary_search: 'text-sky-500 border-sky-500/30 bg-sky-500/10',
-    sliding_window: 'text-indigo-500 border-indigo-500/30 bg-indigo-500/10',
-    linked_list: 'text-pink-500 border-pink-500/30 bg-pink-500/10',
-    trees: 'text-teal-500 border-teal-500/30 bg-teal-500/10',
-    tries: 'text-purple-500 border-purple-500/30 bg-purple-500/10',
-    heap_and_priority_queue: 'text-fuchsia-500 border-fuchsia-500/30 bg-fuchsia-500/10',
-    intervals: 'text-rose-500 border-rose-500/30 bg-rose-500/10',
-    greedy: 'text-blue-400 border-blue-400/30 bg-blue-400/10',
-    backtracking: 'text-violet-400 border-violet-400/30 bg-violet-400/10',
-    graphs: 'text-cyan-400 border-cyan-400/30 bg-cyan-400/10',
-    dynamic_programming: 'text-sky-400 border-sky-400/30 bg-sky-400/10',
+	arrays_and_hashing: 'text-blue-500 border-blue-500/30 bg-blue-500/10',
+	two_pointers: 'text-cyan-500 border-cyan-500/30 bg-cyan-500/10',
+	stack: 'text-violet-500 border-violet-500/30 bg-violet-500/10',
+	binary_search: 'text-sky-500 border-sky-500/30 bg-sky-500/10',
+	sliding_window: 'text-indigo-500 border-indigo-500/30 bg-indigo-500/10',
+	linked_list: 'text-pink-500 border-pink-500/30 bg-pink-500/10',
+	trees: 'text-teal-500 border-teal-500/30 bg-teal-500/10',
+	tries: 'text-purple-500 border-purple-500/30 bg-purple-500/10',
+	heap_and_priority_queue: 'text-fuchsia-500 border-fuchsia-500/30 bg-fuchsia-500/10',
+	intervals: 'text-rose-500 border-rose-500/30 bg-rose-500/10',
+	greedy: 'text-blue-400 border-blue-400/30 bg-blue-400/10',
+	backtracking: 'text-violet-400 border-violet-400/30 bg-violet-400/10',
+	graphs: 'text-cyan-400 border-cyan-400/30 bg-cyan-400/10',
+	dynamic_programming: 'text-sky-400 border-sky-400/30 bg-sky-400/10',
 };
 
 const difficultyColors = {
-    easy: 'text-success border-success/30 bg-success/10',
-    medium: 'text-warning border-warning/30 bg-warning/10',
-    hard: 'text-destructive border-destructive/30 bg-destructive/10',
+	easy: 'text-success border-success/30 bg-success/10',
+	medium: 'text-warning border-warning/30 bg-warning/10',
+	hard: 'text-destructive border-destructive/30 bg-destructive/10',
 };
 
 function formatDate(iso: string): string {
-    return new Date(iso).toLocaleString(undefined, {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-        hour: '2-digit',
-        minute: '2-digit',
-    });
+	return new Date(iso).toLocaleString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+	});
 }
 
 const History = () => {
-    const navigate = useNavigate();
-    const { user } = useAppStore();
-    const [history, setHistory] = useState<HistoryEntry[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [expandedId, setExpandedId] = useState<string | null>(null);
+	const navigate = useNavigate();
+	const { user } = useAppStore();
+	const [history, setHistory] = useState<HistoryEntry[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [expandedId, setExpandedId] = useState<string | null>(null);
 
-    useEffect(() => {
-        if (user == null) {
-            navigate('/login');
-            return;
-        }
-        fetchHistory(user.id);
-    }, [user]);
+	useEffect(() => {
+		if (user == null) {
+			navigate('/login');
+			return;
+		}
+		fetchHistory(user.id);
+	}, [user]);
 
-    const fetchHistory = async (userId: string) => {
-        try {
-            setLoading(true);
-            setError(null);
+	const fetchHistory = async (userId: string) => {
+		try {
+			setLoading(true);
+			setError(null);
 
-            const { data: { session } } = await supabase.auth.getSession();
+			const { data: { session } } = await supabase.auth.getSession();
 
-            const response = await fetch(SUPABASE_ENDPOINTS.getHistory(userId), {
-                headers: {
-                    apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
-                    Authorization: `Bearer ${session?.access_token}`,
-                },
-            });
+			const response = await fetch(SUPABASE_ENDPOINTS.getHistory(userId), {
+				headers: {
+					apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+					Authorization: `Bearer ${session?.access_token}`,
+				},
+			});
 
-            const rows = await response.json();
-            if (!response.ok) throw new Error('Failed to fetch history');
+			const rows = await response.json();
+			if (!response.ok) throw new Error('Failed to fetch history');
 
-            const enriched = await Promise.all(
-                rows.map(async (row: any) => {
-                    const [question, partnerName] = await Promise.all([
-                    fetchQuestion(row.question_id, session?.access_token),
-                    fetchPartnerUsername(row.partner_id, session?.access_token),
-                    ]);
+			const enriched = await Promise.all(
+				rows.map(async (row: any) => {
+					const [question, partnerName] = await Promise.all([
+						fetchQuestion(row.question_id, session?.access_token),
+						fetchPartnerUsername(row.partner_id, session?.access_token),
+					]);
 
-                    return {
-                        id: String(row.id),
-                        question_id: String(row.question_id),
-                        session_id: String(row.session_id),
-                        created_at: row.created_at,
-                        solution: row.solution,
-                        question_title: question?.title ?? `Question #${row.question_id}`,
-                        question_description: question?.description ?? '',
-                        question_difficulty: question?.difficulty ?? 'easy',
-                        question_topic: question?.topic ?? [],
-                        peer_username: partnerName ?? 'Unknown',
-                    } as HistoryEntry;
-                })
-            );
+					return {
+						id: String(row.id),
+						question_id: String(row.question_id),
+						session_id: String(row.session_id),
+						created_at: row.created_at,
+						solution: row.solution,
+						question_title: question?.title ?? `Question #${row.question_id}`,
+						question_description: question?.description ?? '',
+						question_difficulty: question?.difficulty ?? 'easy',
+						question_topic: question?.topic ?? [],
+						peer_username: partnerName ?? 'Unknown',
+					} as HistoryEntry;
+				})
+			);
 
-            setHistory(enriched);
-        } catch (err: any) {
-            setError(err.message);
-        } finally {
-            setLoading(false);
-        }
-    };
+			setHistory(enriched);
+		} catch (err: any) {
+			setError(err.message);
+		} finally {
+			setLoading(false);
+		}
+	};
 
-    const fetchQuestion = async (questionId: number, accessToken?: string) => {
-        try {
-            const response = await fetch(QUESTION_ENDPOINTS.getQuestionById(String(questionId)), {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            });
-            if (!response.ok) return null;
-            return await response.json();
-        } catch {
-            return null;
-        }
-    };
+	const fetchQuestion = async (questionId: number, accessToken?: string) => {
+		try {
+			const response = await fetch(QUESTION_ENDPOINTS.getQuestionById(String(questionId)), {
+				headers: { Authorization: `Bearer ${accessToken}` },
+			});
+			if (!response.ok) return null;
+			return await response.json();
+		} catch {
+			return null;
+		}
+	};
 
-    const fetchPartnerUsername = async (partnerId: string, accessToken?: string) => {
-        try {
-            if (!partnerId) return null;
-            const response = await fetch(USER_ENDPOINTS.getNameById(partnerId), {
-                headers: { Authorization: `Bearer ${accessToken}` },
-            });
-            if (!response.ok) return null;
-            const data = await response.json();
-            return data.name ?? null;
-        } catch {
-            return null;
-        }
-    };
+	const fetchPartnerUsername = async (partnerId: string, accessToken?: string) => {
+		try {
+			if (!partnerId) return null;
+			const response = await fetch(USER_ENDPOINTS.getNameById(partnerId), {
+				headers: { Authorization: `Bearer ${accessToken}` },
+			});
+			if (!response.ok) return null;
+			const data = await response.json();
+			return data.name ?? null;
+		} catch {
+			return null;
+		}
+	};
 
-    const toggleExpand = (id: string) => {
-        setExpandedId((prev) => (prev === id ? null : id));
-    };
+	const toggleExpand = (id: string) => {
+		setExpandedId((prev) => (prev === id ? null : id));
+	};
 
-    return (
-        <div className="min-h-screen bg-background">
-            <div className="absolute inset-0 gradient-glow opacity-20" />
+	return (
+		<div className="min-h-screen bg-background">
+			<div className="absolute inset-0 gradient-glow opacity-20" />
 
-            {/* Header */}
-            <header className="relative z-10 border-b border-border/50 bg-background/80 backdrop-blur-xl">
-                <div className="container mx-auto px-6 h-16 flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                        <div className="h-8 w-8 rounded-lg gradient-primary flex items-center justify-center shadow-glow">
-                            <Code2 className="h-5 w-5 text-primary-foreground" />
-                        </div>
-                        <span className="text-xl font-bold text-gradient">PeerPrep</span>
-                    </div>
-                    <Button variant="ghost" size="sm" onClick={() => navigate('/match')}>
-                        <ArrowLeft className="h-4 w-4 mr-2" />
-                        Back
-                    </Button>
-                </div>
-            </header>
+			{/* Header */}
+			<header className="relative z-10 border-b border-border/50 bg-background/80 backdrop-blur-xl">
+				<div className="container mx-auto px-6 h-16 flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<div className="h-8 w-8 rounded-lg gradient-primary flex items-center justify-center shadow-glow">
+							<Code2 className="h-5 w-5 text-primary-foreground" />
+						</div>
+						<span className="text-xl font-bold text-gradient">PeerPrep</span>
+					</div>
+					<Button variant="ghost" size="sm" onClick={() => navigate('/match')}>
+						<ArrowLeft className="h-4 w-4 mr-2" />
+						Back
+					</Button>
+				</div>
+			</header>
 
-            {/* Main Content */}
-            <main className="relative z-10 container mx-auto px-6 py-12 max-w-4xl">
+			{/* Main Content */}
+			<main className="relative z-10 container mx-auto px-6 py-12 max-w-4xl">
 
-                {/* Title */}
-                <div className="flex items-center justify-between mb-12 animate-fade-in">
-                    <div>
-                        <h1 className="text-3xl md:text-4xl font-bold mb-2">
-                            Attempt <span className="text-gradient">History</span>
-                        </h1>
-                        <p className="text-muted-foreground">Your past collaborative sessions</p>
-                    </div>
-                    {/* Summary badge */}
-                    {!loading && history.length > 0 && (
-                        <div className="text-sm text-muted-foreground border border-border rounded-lg px-4 py-2 bg-card">
-                            {history.length} attempt{history.length !== 1 ? 's' : ''}
-                        </div>
-                    )}
-                </div>
+				{/* Title */}
+				<div className="flex items-center justify-between mb-12 animate-fade-in">
+					<div>
+						<h1 className="text-3xl md:text-4xl font-bold mb-2">
+							Attempt <span className="text-gradient">History</span>
+						</h1>
+						<p className="text-muted-foreground">Your past collaborative sessions</p>
+					</div>
+					{/* Summary badge */}
+					{!loading && history.length > 0 && (
+						<div className="text-sm text-muted-foreground border border-border rounded-lg px-4 py-2 bg-card">
+							{history.length} attempt{history.length !== 1 ? 's' : ''}
+						</div>
+					)}
+				</div>
 
-                {/* List */}
-                <div className="animate-fade-in" style={{ animationDelay: '0.1s' }}>
-                    {loading ? (
-                        <div className="flex items-center justify-center py-12">
-                            <Loader2 className="h-6 w-6 animate-spin text-primary" />
-                        </div>
-                    ) : error ? (
-                        <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
-                            <p className="text-destructive text-sm">{error}</p>
-                        </div>
-                    ) : history.length === 0 ? (
-                        <div className="rounded-xl border border-border bg-card p-12 text-center">
-                            <FileText className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
-                            <p className="text-foreground font-medium">No attempts yet</p>
-                            <p className="text-sm text-muted-foreground mt-1">
-                                Complete a session to see your history here.
-                            </p>
-                        </div>
-                    ) : (
-                        <div className="space-y-4">
-                            {history.map((entry) => {
-                                const isExpanded = expandedId === entry.id;
-                                return (
-                                    <div
-                                        key={entry.id}
-                                        className="rounded-xl border border-border bg-card overflow-hidden"
-                                    >
-                                        {/* Row */}
-                                        <div className="p-6 flex items-center justify-between gap-4">
-                                            <div className="flex-1 min-w-0">
+				{/* List */}
+				<div className="animate-fade-in" style={{ animationDelay: '0.1s' }}>
+					{loading ? (
+						<div className="flex items-center justify-center py-12">
+							<Loader2 className="h-6 w-6 animate-spin text-primary" />
+						</div>
+					) : error ? (
+						<div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+							<p className="text-destructive text-sm">{error}</p>
+						</div>
+					) : history.length === 0 ? (
+						<div className="rounded-xl border border-border bg-card p-12 text-center">
+							<FileText className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
+							<p className="text-foreground font-medium">No attempts yet</p>
+							<p className="text-sm text-muted-foreground mt-1">
+								Complete a session to see your history here.
+							</p>
+						</div>
+					) : (
+						<div className="space-y-4">
+							{history.map((entry) => {
+								const isExpanded = expandedId === entry.id;
+								return (
+									<div
+										key={entry.id}
+										className="rounded-xl border border-border bg-card overflow-hidden"
+									>
+										{/* Row */}
+										<div className="p-6 flex items-center justify-between gap-4">
+											<div className="flex-1 min-w-0">
 
-                                                {/* Title + difficulty */}
-                                                <div className="flex items-center gap-3 mb-1">
-                                                    <p className="font-medium text-foreground truncate">
-                                                        {entry.question_title ?? `Question #${entry.question_id}`}
-                                                    </p>
-                                                    {entry.question_difficulty && (
-                                                        <span
-                                                            className={cn(
-                                                                'text-xs px-2 py-0.5 rounded-full border capitalize shrink-0',
-                                                                difficultyColors[entry.question_difficulty],
-                                                            )}
-                                                        >
-                                                            {entry.question_difficulty}
-                                                        </span>
-                                                    )}
-                                                </div>
+												{/* Title + difficulty */}
+												<div className="flex items-center gap-3 mb-1">
+													<p className="font-medium text-foreground truncate">
+														{entry.question_title ?? `Question #${entry.question_id}`}
+													</p>
+													{entry.question_difficulty && (
+														<span
+															className={cn(
+																'text-xs px-2 py-0.5 rounded-full border capitalize shrink-0',
+																difficultyColors[entry.question_difficulty],
+															)}
+														>
+															{entry.question_difficulty}
+														</span>
+													)}
+												</div>
 
-                                                {/* Meta row */}
-                                                <div className="flex items-center gap-3 text-xs text-muted-foreground mb-2">
-                                                    <span className="flex items-center gap-1">
-                                                        <Clock className="h-3 w-3" />
-                                                        {formatDate(entry.created_at)}
-                                                    </span>
-                                                    {entry.peer_username && (
-                                                        <>
-                                                            <span>·</span>
-                                                            <span>with <span className="text-foreground">{entry.peer_username}</span></span>
-                                                        </>
-                                                    )}
-                                                </div>
+												{/* Meta row */}
+												<div className="flex items-center gap-3 text-xs text-muted-foreground mb-2">
+													<span className="flex items-center gap-1">
+														<Clock className="h-3 w-3" />
+														{formatDate(entry.created_at)}
+													</span>
+													{entry.peer_username && (
+														<>
+															<span>·</span>
+															<span>with <span className="text-foreground">{entry.peer_username}</span></span>
+														</>
+													)}
+												</div>
 
-                                                {/* Topics */}
-                                                {entry.question_topic && entry.question_topic.length > 0 && (
-                                                    <div className="flex flex-wrap gap-1">
-                                                        {entry.question_topic.map((t) => (
-                                                            <span
-                                                                key={t}
-                                                                className={cn(
-                                                                    'text-xs px-2 py-0.5 rounded-full capitalize border shrink-0',
-                                                                    topicColors[t] ?? 'text-muted-foreground border-border bg-muted',
-                                                                )}
-                                                            >
-                                                                {t.replace(/_/g, ' ')}
-                                                            </span>
-                                                        ))}
-                                                    </div>
-                                                )}
-                                            </div>
+												{/* Topics */}
+												{entry.question_topic && entry.question_topic.length > 0 && (
+													<div className="flex flex-wrap gap-1">
+														{entry.question_topic.map((t) => (
+															<span
+																key={t}
+																className={cn(
+																	'text-xs px-2 py-0.5 rounded-full capitalize border shrink-0',
+																	topicColors[t] ?? 'text-muted-foreground border-border bg-muted',
+																)}
+															>
+																{t.replace(/_/g, ' ')}
+															</span>
+														))}
+													</div>
+												)}
+											</div>
 
-                                            {/* Expand toggle */}
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                onClick={() => toggleExpand(entry.id)}
-                                                className="shrink-0"
-                                            >
-                                                {isExpanded ? (
-                                                    <ChevronUp className="h-4 w-4" />
-                                                ) : (
-                                                    <ChevronDown className="h-4 w-4" />
-                                                )}
-                                            </Button>
-                                        </div>
+											{/* Expand toggle */}
+											<Button
+												variant="ghost"
+												size="sm"
+												onClick={() => toggleExpand(entry.id)}
+												className="shrink-0"
+											>
+												{isExpanded ? (
+													<ChevronUp className="h-4 w-4" />
+												) : (
+													<ChevronDown className="h-4 w-4" />
+												)}
+											</Button>
+										</div>
 
-                                        {/* Expanded solution */}
-                                        {isExpanded && (
-                                            <div className="border-t border-border px-6 pb-6 pt-4">
-                                                <p className="text-sm mb-4">
-                                                    {entry.question_description}
-                                                </p>
-                                                <p className="text-xs text-muted-foreground mb-2 uppercase tracking-wide">
-                                                    Submitted solution
-                                                </p>
-                                                <pre className="rounded-lg border border-border bg-background p-4 text-sm text-foreground overflow-x-auto font-mono leading-relaxed whitespace-pre">
-                                                    {entry.solution || '// No solution recorded.'}
-                                                </pre>
-                                                <div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
-                                                    <span>Session ID: <span className="font-mono">{entry.session_id}</span></span>
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                );
-                            })}
-                        </div>
-                    )}
-                </div>
-            </main>
-        </div>
-    );
+										{/* Expanded solution */}
+										{isExpanded && (
+											<div className="border-t border-border px-6 pb-6 pt-4">
+												<p className="text-sm mb-4">
+													{entry.question_description}
+												</p>
+												<p className="text-xs text-muted-foreground mb-2 uppercase tracking-wide">
+													Submitted solution
+												</p>
+												<pre className="rounded-lg border border-border bg-background p-4 text-sm text-foreground overflow-x-auto font-mono leading-relaxed whitespace-pre">
+													{entry.solution || '// No solution recorded.'}
+												</pre>
+												<div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
+													<span>Session ID: <span className="font-mono">{entry.session_id}</span></span>
+												</div>
+											</div>
+										)}
+									</div>
+								);
+							})}
+						</div>
+					)}
+				</div>
+			</main>
+		</div>
+	);
 };
 
 export default History;

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -8,304 +8,306 @@ import { supabase } from '@/lib/supabase';
 import { USER_ENDPOINTS, QUESTION_ENDPOINTS, SUPABASE_ENDPOINTS } from '@/lib/api';
 
 interface HistoryEntry {
-	id: string;
-	question_id: string;
-	session_id: string;
-	created_at: string;
-	solution?: string;
-	question_title: string;
-	question_description: string;
-	question_difficulty: 'easy' | 'medium' | 'hard';
-	question_topic: string[];
-	peer_username?: string;
+  id: string;
+  question_id: string;
+  session_id: string;
+  created_at: string;
+  solution?: string;
+  question_title: string;
+  question_description: string;
+  question_difficulty: 'easy' | 'medium' | 'hard';
+  question_topic: string[];
+  peer_username?: string;
 }
 
 const topicColors: Record<string, string> = {
-	arrays_and_hashing: 'text-blue-500 border-blue-500/30 bg-blue-500/10',
-	two_pointers: 'text-cyan-500 border-cyan-500/30 bg-cyan-500/10',
-	stack: 'text-violet-500 border-violet-500/30 bg-violet-500/10',
-	binary_search: 'text-sky-500 border-sky-500/30 bg-sky-500/10',
-	sliding_window: 'text-indigo-500 border-indigo-500/30 bg-indigo-500/10',
-	linked_list: 'text-pink-500 border-pink-500/30 bg-pink-500/10',
-	trees: 'text-teal-500 border-teal-500/30 bg-teal-500/10',
-	tries: 'text-purple-500 border-purple-500/30 bg-purple-500/10',
-	heap_and_priority_queue: 'text-fuchsia-500 border-fuchsia-500/30 bg-fuchsia-500/10',
-	intervals: 'text-rose-500 border-rose-500/30 bg-rose-500/10',
-	greedy: 'text-blue-400 border-blue-400/30 bg-blue-400/10',
-	backtracking: 'text-violet-400 border-violet-400/30 bg-violet-400/10',
-	graphs: 'text-cyan-400 border-cyan-400/30 bg-cyan-400/10',
-	dynamic_programming: 'text-sky-400 border-sky-400/30 bg-sky-400/10',
+  arrays_and_hashing: 'text-blue-500 border-blue-500/30 bg-blue-500/10',
+  two_pointers: 'text-cyan-500 border-cyan-500/30 bg-cyan-500/10',
+  stack: 'text-violet-500 border-violet-500/30 bg-violet-500/10',
+  binary_search: 'text-sky-500 border-sky-500/30 bg-sky-500/10',
+  sliding_window: 'text-indigo-500 border-indigo-500/30 bg-indigo-500/10',
+  linked_list: 'text-pink-500 border-pink-500/30 bg-pink-500/10',
+  trees: 'text-teal-500 border-teal-500/30 bg-teal-500/10',
+  tries: 'text-purple-500 border-purple-500/30 bg-purple-500/10',
+  heap_and_priority_queue: 'text-fuchsia-500 border-fuchsia-500/30 bg-fuchsia-500/10',
+  intervals: 'text-rose-500 border-rose-500/30 bg-rose-500/10',
+  greedy: 'text-blue-400 border-blue-400/30 bg-blue-400/10',
+  backtracking: 'text-violet-400 border-violet-400/30 bg-violet-400/10',
+  graphs: 'text-cyan-400 border-cyan-400/30 bg-cyan-400/10',
+  dynamic_programming: 'text-sky-400 border-sky-400/30 bg-sky-400/10',
 };
 
 const difficultyColors = {
-	easy: 'text-success border-success/30 bg-success/10',
-	medium: 'text-warning border-warning/30 bg-warning/10',
-	hard: 'text-destructive border-destructive/30 bg-destructive/10',
+  easy: 'text-success border-success/30 bg-success/10',
+  medium: 'text-warning border-warning/30 bg-warning/10',
+  hard: 'text-destructive border-destructive/30 bg-destructive/10',
 };
 
 function formatDate(iso: string): string {
-	return new Date(iso).toLocaleString(undefined, {
-		year: 'numeric',
-		month: 'short',
-		day: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-	});
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 const History = () => {
-	const navigate = useNavigate();
-	const { user } = useAppStore();
-	const [history, setHistory] = useState<HistoryEntry[]>([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState<string | null>(null);
-	const [expandedId, setExpandedId] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { user } = useAppStore();
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
-	useEffect(() => {
-		if (user == null) {
-			navigate('/login');
-			return;
-		}
-		fetchHistory(user.id);
-	}, [user]);
+  useEffect(() => {
+    if (user == null) {
+      navigate('/login');
+      return;
+    }
+    fetchHistory(user.id);
+  }, [user]);
 
-	const fetchHistory = async (userId: string) => {
-		try {
-			setLoading(true);
-			setError(null);
+  const fetchHistory = async (userId: string) => {
+    try {
+      setLoading(true);
+      setError(null);
 
-			const { data: { session } } = await supabase.auth.getSession();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
 
-			const response = await fetch(SUPABASE_ENDPOINTS.getHistory(userId), {
-				headers: {
-					apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
-					Authorization: `Bearer ${session?.access_token}`,
-				},
-			});
+      const response = await fetch(SUPABASE_ENDPOINTS.getHistory(userId), {
+        headers: {
+          apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+      });
 
-			const rows = await response.json();
-			if (!response.ok) throw new Error('Failed to fetch history');
+      const rows = await response.json();
+      if (!response.ok) throw new Error('Failed to fetch history');
 
-			const enriched = await Promise.all(
-				rows.map(async (row: any) => {
-					const [question, partnerName] = await Promise.all([
-						fetchQuestion(row.question_id, session?.access_token),
-						fetchPartnerUsername(row.partner_id, session?.access_token),
-					]);
+      const enriched = await Promise.all(
+        rows.map(async (row: any) => {
+          const [question, partnerName] = await Promise.all([
+            fetchQuestion(row.question_id, session?.access_token),
+            fetchPartnerUsername(row.partner_id, session?.access_token),
+          ]);
 
-					return {
-						id: String(row.id),
-						question_id: String(row.question_id),
-						session_id: String(row.session_id),
-						created_at: row.created_at,
-						solution: row.solution,
-						question_title: question?.title ?? `Question #${row.question_id}`,
-						question_description: question?.description ?? '',
-						question_difficulty: question?.difficulty ?? 'easy',
-						question_topic: question?.topic ?? [],
-						peer_username: partnerName ?? 'Unknown',
-					} as HistoryEntry;
-				})
-			);
+          return {
+            id: String(row.id),
+            question_id: String(row.question_id),
+            session_id: String(row.session_id),
+            created_at: row.created_at,
+            solution: row.solution,
+            question_title: question?.title ?? `Question #${row.question_id}`,
+            question_description: question?.description ?? '',
+            question_difficulty: question?.difficulty ?? 'easy',
+            question_topic: question?.topic ?? [],
+            peer_username: partnerName ?? 'Unknown',
+          } as HistoryEntry;
+        }),
+      );
 
-			setHistory(enriched);
-		} catch (err: any) {
-			setError(err.message);
-		} finally {
-			setLoading(false);
-		}
-	};
+      setHistory(enriched);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-	const fetchQuestion = async (questionId: number, accessToken?: string) => {
-		try {
-			const response = await fetch(QUESTION_ENDPOINTS.getQuestionById(String(questionId)), {
-				headers: { Authorization: `Bearer ${accessToken}` },
-			});
-			if (!response.ok) return null;
-			return await response.json();
-		} catch {
-			return null;
-		}
-	};
+  const fetchQuestion = async (questionId: number, accessToken?: string) => {
+    try {
+      const response = await fetch(QUESTION_ENDPOINTS.getQuestionById(String(questionId)), {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!response.ok) return null;
+      return await response.json();
+    } catch {
+      return null;
+    }
+  };
 
-	const fetchPartnerUsername = async (partnerId: string, accessToken?: string) => {
-		try {
-			if (!partnerId) return null;
-			const response = await fetch(USER_ENDPOINTS.getNameById(partnerId), {
-				headers: { Authorization: `Bearer ${accessToken}` },
-			});
-			if (!response.ok) return null;
-			const data = await response.json();
-			return data.name ?? null;
-		} catch {
-			return null;
-		}
-	};
+  const fetchPartnerUsername = async (partnerId: string, accessToken?: string) => {
+    try {
+      if (!partnerId) return null;
+      const response = await fetch(USER_ENDPOINTS.getNameById(partnerId), {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (!response.ok) return null;
+      const data = await response.json();
+      return data.name ?? null;
+    } catch {
+      return null;
+    }
+  };
 
-	const toggleExpand = (id: string) => {
-		setExpandedId((prev) => (prev === id ? null : id));
-	};
+  const toggleExpand = (id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  };
 
-	return (
-		<div className="min-h-screen bg-background">
-			<div className="absolute inset-0 gradient-glow opacity-20" />
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="absolute inset-0 gradient-glow opacity-20" />
 
-			{/* Header */}
-			<header className="relative z-10 border-b border-border/50 bg-background/80 backdrop-blur-xl">
-				<div className="container mx-auto px-6 h-16 flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<div className="h-8 w-8 rounded-lg gradient-primary flex items-center justify-center shadow-glow">
-							<Code2 className="h-5 w-5 text-primary-foreground" />
-						</div>
-						<span className="text-xl font-bold text-gradient">PeerPrep</span>
-					</div>
-					<Button variant="ghost" size="sm" onClick={() => navigate('/match')}>
-						<ArrowLeft className="h-4 w-4 mr-2" />
-						Back
-					</Button>
-				</div>
-			</header>
+      {/* Header */}
+      <header className="relative z-10 border-b border-border/50 bg-background/80 backdrop-blur-xl">
+        <div className="container mx-auto px-6 h-16 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-lg gradient-primary flex items-center justify-center shadow-glow">
+              <Code2 className="h-5 w-5 text-primary-foreground" />
+            </div>
+            <span className="text-xl font-bold text-gradient">PeerPrep</span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => navigate('/match')}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back
+          </Button>
+        </div>
+      </header>
 
-			{/* Main Content */}
-			<main className="relative z-10 container mx-auto px-6 py-12 max-w-4xl">
+      {/* Main Content */}
+      <main className="relative z-10 container mx-auto px-6 py-12 max-w-4xl">
+        {/* Title */}
+        <div className="flex items-center justify-between mb-12 animate-fade-in">
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold mb-2">
+              Attempt <span className="text-gradient">History</span>
+            </h1>
+            <p className="text-muted-foreground">Your past collaborative sessions</p>
+          </div>
+          {/* Summary badge */}
+          {!loading && history.length > 0 && (
+            <div className="text-sm text-muted-foreground border border-border rounded-lg px-4 py-2 bg-card">
+              {history.length} attempt{history.length !== 1 ? 's' : ''}
+            </div>
+          )}
+        </div>
 
-				{/* Title */}
-				<div className="flex items-center justify-between mb-12 animate-fade-in">
-					<div>
-						<h1 className="text-3xl md:text-4xl font-bold mb-2">
-							Attempt <span className="text-gradient">History</span>
-						</h1>
-						<p className="text-muted-foreground">Your past collaborative sessions</p>
-					</div>
-					{/* Summary badge */}
-					{!loading && history.length > 0 && (
-						<div className="text-sm text-muted-foreground border border-border rounded-lg px-4 py-2 bg-card">
-							{history.length} attempt{history.length !== 1 ? 's' : ''}
-						</div>
-					)}
-				</div>
+        {/* List */}
+        <div className="animate-fade-in" style={{ animationDelay: '0.1s' }}>
+          {loading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-primary" />
+            </div>
+          ) : error ? (
+            <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+              <p className="text-destructive text-sm">{error}</p>
+            </div>
+          ) : history.length === 0 ? (
+            <div className="rounded-xl border border-border bg-card p-12 text-center">
+              <FileText className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
+              <p className="text-foreground font-medium">No attempts yet</p>
+              <p className="text-sm text-muted-foreground mt-1">
+                Complete a session to see your history here.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {history.map((entry) => {
+                const isExpanded = expandedId === entry.id;
+                return (
+                  <div
+                    key={entry.id}
+                    className="rounded-xl border border-border bg-card overflow-hidden"
+                  >
+                    {/* Row */}
+                    <div className="p-6 flex items-center justify-between gap-4">
+                      <div className="flex-1 min-w-0">
+                        {/* Title + difficulty */}
+                        <div className="flex items-center gap-3 mb-1">
+                          <p className="font-medium text-foreground truncate">
+                            {entry.question_title ?? `Question #${entry.question_id}`}
+                          </p>
+                          {entry.question_difficulty && (
+                            <span
+                              className={cn(
+                                'text-xs px-2 py-0.5 rounded-full border capitalize shrink-0',
+                                difficultyColors[entry.question_difficulty],
+                              )}
+                            >
+                              {entry.question_difficulty}
+                            </span>
+                          )}
+                        </div>
 
-				{/* List */}
-				<div className="animate-fade-in" style={{ animationDelay: '0.1s' }}>
-					{loading ? (
-						<div className="flex items-center justify-center py-12">
-							<Loader2 className="h-6 w-6 animate-spin text-primary" />
-						</div>
-					) : error ? (
-						<div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
-							<p className="text-destructive text-sm">{error}</p>
-						</div>
-					) : history.length === 0 ? (
-						<div className="rounded-xl border border-border bg-card p-12 text-center">
-							<FileText className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
-							<p className="text-foreground font-medium">No attempts yet</p>
-							<p className="text-sm text-muted-foreground mt-1">
-								Complete a session to see your history here.
-							</p>
-						</div>
-					) : (
-						<div className="space-y-4">
-							{history.map((entry) => {
-								const isExpanded = expandedId === entry.id;
-								return (
-									<div
-										key={entry.id}
-										className="rounded-xl border border-border bg-card overflow-hidden"
-									>
-										{/* Row */}
-										<div className="p-6 flex items-center justify-between gap-4">
-											<div className="flex-1 min-w-0">
+                        {/* Meta row */}
+                        <div className="flex items-center gap-3 text-xs text-muted-foreground mb-2">
+                          <span className="flex items-center gap-1">
+                            <Clock className="h-3 w-3" />
+                            {formatDate(entry.created_at)}
+                          </span>
+                          {entry.peer_username && (
+                            <>
+                              <span>·</span>
+                              <span>
+                                with <span className="text-foreground">{entry.peer_username}</span>
+                              </span>
+                            </>
+                          )}
+                        </div>
 
-												{/* Title + difficulty */}
-												<div className="flex items-center gap-3 mb-1">
-													<p className="font-medium text-foreground truncate">
-														{entry.question_title ?? `Question #${entry.question_id}`}
-													</p>
-													{entry.question_difficulty && (
-														<span
-															className={cn(
-																'text-xs px-2 py-0.5 rounded-full border capitalize shrink-0',
-																difficultyColors[entry.question_difficulty],
-															)}
-														>
-															{entry.question_difficulty}
-														</span>
-													)}
-												</div>
+                        {/* Topics */}
+                        {entry.question_topic && entry.question_topic.length > 0 && (
+                          <div className="flex flex-wrap gap-1">
+                            {entry.question_topic.map((t) => (
+                              <span
+                                key={t}
+                                className={cn(
+                                  'text-xs px-2 py-0.5 rounded-full capitalize border shrink-0',
+                                  topicColors[t] ?? 'text-muted-foreground border-border bg-muted',
+                                )}
+                              >
+                                {t.replace(/_/g, ' ')}
+                              </span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
 
-												{/* Meta row */}
-												<div className="flex items-center gap-3 text-xs text-muted-foreground mb-2">
-													<span className="flex items-center gap-1">
-														<Clock className="h-3 w-3" />
-														{formatDate(entry.created_at)}
-													</span>
-													{entry.peer_username && (
-														<>
-															<span>·</span>
-															<span>with <span className="text-foreground">{entry.peer_username}</span></span>
-														</>
-													)}
-												</div>
+                      {/* Expand toggle */}
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => toggleExpand(entry.id)}
+                        className="shrink-0"
+                      >
+                        {isExpanded ? (
+                          <ChevronUp className="h-4 w-4" />
+                        ) : (
+                          <ChevronDown className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
 
-												{/* Topics */}
-												{entry.question_topic && entry.question_topic.length > 0 && (
-													<div className="flex flex-wrap gap-1">
-														{entry.question_topic.map((t) => (
-															<span
-																key={t}
-																className={cn(
-																	'text-xs px-2 py-0.5 rounded-full capitalize border shrink-0',
-																	topicColors[t] ?? 'text-muted-foreground border-border bg-muted',
-																)}
-															>
-																{t.replace(/_/g, ' ')}
-															</span>
-														))}
-													</div>
-												)}
-											</div>
-
-											{/* Expand toggle */}
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => toggleExpand(entry.id)}
-												className="shrink-0"
-											>
-												{isExpanded ? (
-													<ChevronUp className="h-4 w-4" />
-												) : (
-													<ChevronDown className="h-4 w-4" />
-												)}
-											</Button>
-										</div>
-
-										{/* Expanded solution */}
-										{isExpanded && (
-											<div className="border-t border-border px-6 pb-6 pt-4">
-												<p className="text-sm mb-4">
-													{entry.question_description}
-												</p>
-												<p className="text-xs text-muted-foreground mb-2 uppercase tracking-wide">
-													Submitted solution
-												</p>
-												<pre className="rounded-lg border border-border bg-background p-4 text-sm text-foreground overflow-x-auto font-mono leading-relaxed whitespace-pre">
-													{entry.solution || '// No solution recorded.'}
-												</pre>
-												<div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
-													<span>Session ID: <span className="font-mono">{entry.session_id}</span></span>
-												</div>
-											</div>
-										)}
-									</div>
-								);
-							})}
-						</div>
-					)}
-				</div>
-			</main>
-		</div>
-	);
+                    {/* Expanded solution */}
+                    {isExpanded && (
+                      <div className="border-t border-border px-6 pb-6 pt-4">
+                        <p className="text-sm mb-4">{entry.question_description}</p>
+                        <p className="text-xs text-muted-foreground mb-2 uppercase tracking-wide">
+                          Submitted solution
+                        </p>
+                        <pre className="rounded-lg border border-border bg-background p-4 text-sm text-foreground overflow-x-auto font-mono leading-relaxed whitespace-pre">
+                          {entry.solution || '// No solution recorded.'}
+                        </pre>
+                        <div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
+                          <span>
+                            Session ID: <span className="font-mono">{entry.session_id}</span>
+                          </span>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
 };
 
 export default History;

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1,0 +1,311 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAppStore } from '@/store/useAppStore';
+import { Code2, ArrowLeft, Clock, ChevronDown, ChevronUp, Loader2, FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { supabase } from '@/lib/supabase';
+import { USER_ENDPOINTS, QUESTION_ENDPOINTS, SUPABASE_ENDPOINTS } from '@/lib/api';
+
+interface HistoryEntry {
+    id: string;
+    question_id: string;
+    session_id: string;
+    created_at: string;
+    solution?: string;
+    question_title: string;
+    question_description: string;
+    question_difficulty: 'easy' | 'medium' | 'hard';
+    question_topic: string[];
+    peer_username?: string;
+}
+
+const topicColors: Record<string, string> = {
+    arrays_and_hashing: 'text-blue-500 border-blue-500/30 bg-blue-500/10',
+    two_pointers: 'text-cyan-500 border-cyan-500/30 bg-cyan-500/10',
+    stack: 'text-violet-500 border-violet-500/30 bg-violet-500/10',
+    binary_search: 'text-sky-500 border-sky-500/30 bg-sky-500/10',
+    sliding_window: 'text-indigo-500 border-indigo-500/30 bg-indigo-500/10',
+    linked_list: 'text-pink-500 border-pink-500/30 bg-pink-500/10',
+    trees: 'text-teal-500 border-teal-500/30 bg-teal-500/10',
+    tries: 'text-purple-500 border-purple-500/30 bg-purple-500/10',
+    heap_and_priority_queue: 'text-fuchsia-500 border-fuchsia-500/30 bg-fuchsia-500/10',
+    intervals: 'text-rose-500 border-rose-500/30 bg-rose-500/10',
+    greedy: 'text-blue-400 border-blue-400/30 bg-blue-400/10',
+    backtracking: 'text-violet-400 border-violet-400/30 bg-violet-400/10',
+    graphs: 'text-cyan-400 border-cyan-400/30 bg-cyan-400/10',
+    dynamic_programming: 'text-sky-400 border-sky-400/30 bg-sky-400/10',
+};
+
+const difficultyColors = {
+    easy: 'text-success border-success/30 bg-success/10',
+    medium: 'text-warning border-warning/30 bg-warning/10',
+    hard: 'text-destructive border-destructive/30 bg-destructive/10',
+};
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+    });
+}
+
+const History = () => {
+    const navigate = useNavigate();
+    const { user } = useAppStore();
+    const [history, setHistory] = useState<HistoryEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [expandedId, setExpandedId] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (user == null) {
+            navigate('/login');
+            return;
+        }
+        fetchHistory(user.id);
+    }, [user]);
+
+    const fetchHistory = async (userId: string) => {
+        try {
+            setLoading(true);
+            setError(null);
+
+            const { data: { session } } = await supabase.auth.getSession();
+
+            const response = await fetch(SUPABASE_ENDPOINTS.getHistory(userId), {
+                headers: {
+                    apikey: import.meta.env.VITE_SUPABASE_ANON_KEY,
+                    Authorization: `Bearer ${session?.access_token}`,
+                },
+            });
+
+            const rows = await response.json();
+            if (!response.ok) throw new Error('Failed to fetch history');
+
+            const enriched = await Promise.all(
+                rows.map(async (row: any) => {
+                    const [question, partnerName] = await Promise.all([
+                    fetchQuestion(row.question_id, session?.access_token),
+                    fetchPartnerUsername(row.partner_id, session?.access_token),
+                    ]);
+
+                    return {
+                        id: String(row.id),
+                        question_id: String(row.question_id),
+                        session_id: String(row.session_id),
+                        created_at: row.created_at,
+                        solution: row.solution,
+                        question_title: question?.title ?? `Question #${row.question_id}`,
+                        question_description: question?.description ?? '',
+                        question_difficulty: question?.difficulty ?? 'easy',
+                        question_topic: question?.topic ?? [],
+                        peer_username: partnerName ?? 'Unknown',
+                    } as HistoryEntry;
+                })
+            );
+
+            setHistory(enriched);
+        } catch (err: any) {
+            setError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const fetchQuestion = async (questionId: number, accessToken?: string) => {
+        try {
+            const response = await fetch(QUESTION_ENDPOINTS.getQuestionById(String(questionId)), {
+                headers: { Authorization: `Bearer ${accessToken}` },
+            });
+            if (!response.ok) return null;
+            return await response.json();
+        } catch {
+            return null;
+        }
+    };
+
+    const fetchPartnerUsername = async (partnerId: string, accessToken?: string) => {
+        try {
+            if (!partnerId) return null;
+            const response = await fetch(USER_ENDPOINTS.getNameById(partnerId), {
+                headers: { Authorization: `Bearer ${accessToken}` },
+            });
+            if (!response.ok) return null;
+            const data = await response.json();
+            return data.name ?? null;
+        } catch {
+            return null;
+        }
+    };
+
+    const toggleExpand = (id: string) => {
+        setExpandedId((prev) => (prev === id ? null : id));
+    };
+
+    return (
+        <div className="min-h-screen bg-background">
+            <div className="absolute inset-0 gradient-glow opacity-20" />
+
+            {/* Header */}
+            <header className="relative z-10 border-b border-border/50 bg-background/80 backdrop-blur-xl">
+                <div className="container mx-auto px-6 h-16 flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <div className="h-8 w-8 rounded-lg gradient-primary flex items-center justify-center shadow-glow">
+                            <Code2 className="h-5 w-5 text-primary-foreground" />
+                        </div>
+                        <span className="text-xl font-bold text-gradient">PeerPrep</span>
+                    </div>
+                    <Button variant="ghost" size="sm" onClick={() => navigate('/match')}>
+                        <ArrowLeft className="h-4 w-4 mr-2" />
+                        Back
+                    </Button>
+                </div>
+            </header>
+
+            {/* Main Content */}
+            <main className="relative z-10 container mx-auto px-6 py-12 max-w-4xl">
+
+                {/* Title */}
+                <div className="flex items-center justify-between mb-12 animate-fade-in">
+                    <div>
+                        <h1 className="text-3xl md:text-4xl font-bold mb-2">
+                            Attempt <span className="text-gradient">History</span>
+                        </h1>
+                        <p className="text-muted-foreground">Your past collaborative sessions</p>
+                    </div>
+                    {/* Summary badge */}
+                    {!loading && history.length > 0 && (
+                        <div className="text-sm text-muted-foreground border border-border rounded-lg px-4 py-2 bg-card">
+                            {history.length} attempt{history.length !== 1 ? 's' : ''}
+                        </div>
+                    )}
+                </div>
+
+                {/* List */}
+                <div className="animate-fade-in" style={{ animationDelay: '0.1s' }}>
+                    {loading ? (
+                        <div className="flex items-center justify-center py-12">
+                            <Loader2 className="h-6 w-6 animate-spin text-primary" />
+                        </div>
+                    ) : error ? (
+                        <div className="rounded-xl border border-destructive/50 bg-destructive/10 p-6 text-center">
+                            <p className="text-destructive text-sm">{error}</p>
+                        </div>
+                    ) : history.length === 0 ? (
+                        <div className="rounded-xl border border-border bg-card p-12 text-center">
+                            <FileText className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
+                            <p className="text-foreground font-medium">No attempts yet</p>
+                            <p className="text-sm text-muted-foreground mt-1">
+                                Complete a session to see your history here.
+                            </p>
+                        </div>
+                    ) : (
+                        <div className="space-y-4">
+                            {history.map((entry) => {
+                                const isExpanded = expandedId === entry.id;
+                                return (
+                                    <div
+                                        key={entry.id}
+                                        className="rounded-xl border border-border bg-card overflow-hidden"
+                                    >
+                                        {/* Row */}
+                                        <div className="p-6 flex items-center justify-between gap-4">
+                                            <div className="flex-1 min-w-0">
+
+                                                {/* Title + difficulty */}
+                                                <div className="flex items-center gap-3 mb-1">
+                                                    <p className="font-medium text-foreground truncate">
+                                                        {entry.question_title ?? `Question #${entry.question_id}`}
+                                                    </p>
+                                                    {entry.question_difficulty && (
+                                                        <span
+                                                            className={cn(
+                                                                'text-xs px-2 py-0.5 rounded-full border capitalize shrink-0',
+                                                                difficultyColors[entry.question_difficulty],
+                                                            )}
+                                                        >
+                                                            {entry.question_difficulty}
+                                                        </span>
+                                                    )}
+                                                </div>
+
+                                                {/* Meta row */}
+                                                <div className="flex items-center gap-3 text-xs text-muted-foreground mb-2">
+                                                    <span className="flex items-center gap-1">
+                                                        <Clock className="h-3 w-3" />
+                                                        {formatDate(entry.created_at)}
+                                                    </span>
+                                                    {entry.peer_username && (
+                                                        <>
+                                                            <span>·</span>
+                                                            <span>with <span className="text-foreground">{entry.peer_username}</span></span>
+                                                        </>
+                                                    )}
+                                                </div>
+
+                                                {/* Topics */}
+                                                {entry.question_topic && entry.question_topic.length > 0 && (
+                                                    <div className="flex flex-wrap gap-1">
+                                                        {entry.question_topic.map((t) => (
+                                                            <span
+                                                                key={t}
+                                                                className={cn(
+                                                                    'text-xs px-2 py-0.5 rounded-full capitalize border shrink-0',
+                                                                    topicColors[t] ?? 'text-muted-foreground border-border bg-muted',
+                                                                )}
+                                                            >
+                                                                {t.replace(/_/g, ' ')}
+                                                            </span>
+                                                        ))}
+                                                    </div>
+                                                )}
+                                            </div>
+
+                                            {/* Expand toggle */}
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => toggleExpand(entry.id)}
+                                                className="shrink-0"
+                                            >
+                                                {isExpanded ? (
+                                                    <ChevronUp className="h-4 w-4" />
+                                                ) : (
+                                                    <ChevronDown className="h-4 w-4" />
+                                                )}
+                                            </Button>
+                                        </div>
+
+                                        {/* Expanded solution */}
+                                        {isExpanded && (
+                                            <div className="border-t border-border px-6 pb-6 pt-4">
+                                                <p className="text-sm mb-4">
+                                                    {entry.question_description}
+                                                </p>
+                                                <p className="text-xs text-muted-foreground mb-2 uppercase tracking-wide">
+                                                    Submitted solution
+                                                </p>
+                                                <pre className="rounded-lg border border-border bg-background p-4 text-sm text-foreground overflow-x-auto font-mono leading-relaxed whitespace-pre">
+                                                    {entry.solution || '// No solution recorded.'}
+                                                </pre>
+                                                <div className="flex items-center gap-3 mt-3 text-xs text-muted-foreground">
+                                                    <span>Session ID: <span className="font-mono">{entry.session_id}</span></span>
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </main>
+        </div>
+    );
+};
+
+export default History;

--- a/services/question-service/package.json
+++ b/services/question-service/package.json
@@ -11,9 +11,9 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "vitest --pool=forks",
+    "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest --coverage --pool=forks"
+    "test:coverage": "vitest run --coverage"
   },
   "keywords": [],
   "author": "",

--- a/services/question-service/src/controllers/questionController.ts
+++ b/services/question-service/src/controllers/questionController.ts
@@ -9,14 +9,15 @@ export async function getAllQuestions(_req: Request, res: Response) {
   res.json(data);
 }
 
-export async function getRandomQuestion(_req: Request, res: Response) {
-  const { data, error } = await supabase.from('questions').select('*');
+export async function getQuestionById(req: Request, res: Response) {
+  const { id } = req.params;
+
+  const { data, error } = await supabase.from('questions').select('*').eq('id', id).single();
 
   if (error) return res.status(500).json({ error: error.message });
-  if (!data || data.length === 0) return res.status(404).json({ error: 'No questions found' });
+  if (!data) return res.status(404).json({ error: 'Question not found' });
 
-  const random = data[Math.floor(Math.random() * data.length)];
-  res.json(random);
+  res.json(data);
 }
 
 export async function getRandomQuestionByFilter(req: Request, res: Response) {

--- a/services/question-service/src/routes/questionRoutes.ts
+++ b/services/question-service/src/routes/questionRoutes.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import {
   getAllQuestions,
-  getRandomQuestion,
+  getQuestionById,
   getRandomQuestionByFilter,
   addQuestion,
   updateQuestion,
@@ -13,7 +13,7 @@ const router = Router();
 
 // Public read routes
 router.get('/', getAllQuestions);
-router.get('/random', getRandomQuestion);
+router.get('/:id', getQuestionById);
 router.get('/random/:difficulty/:topic', getRandomQuestionByFilter);
 
 // Admin-only write routes

--- a/services/question-service/src/tests/questionController.test.ts
+++ b/services/question-service/src/tests/questionController.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Request, Response } from 'express';
 import {
   getAllQuestions,
-  getRandomQuestion,
+  getQuestionById,
   getRandomQuestionByFilter,
   addQuestion,
   updateQuestion,
@@ -18,7 +18,7 @@ vi.mock('../lib/supabase', () => {
       delete: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       contains: vi.fn().mockReturnThis(),
-      single: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
     };
     return chain;
   };
@@ -69,38 +69,51 @@ describe('getAllQuestions', () => {
   });
 });
 
-describe('getRandomQuestion', () => {
-  it('returns a random question from the list', async () => {
-    const questions = [{ id: '1' }, { id: '2' }, { id: '3' }];
+describe('getQuestionById', () => {
+  it('returns a question by its ID', async () => {
+    const question = { id: '1', title: 'Two Sum' };
     vi.mocked(supabase.from).mockReturnValueOnce({
-      select: vi.fn().mockResolvedValueOnce({ data: questions, error: null }),
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: question, error: null }),
+        }),
+      }),
     } as any);
 
+    const req = mockReq({ params: { id: '1' } });
     const res = mockRes();
-    await getRandomQuestion(mockReq(), res);
+    await getQuestionById(req, res);
 
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
   });
 
   it('returns 404 when no questions exist', async () => {
     vi.mocked(supabase.from).mockReturnValueOnce({
-      select: vi.fn().mockResolvedValueOnce({ data: [], error: null }),
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
     } as any);
 
     const res = mockRes();
-    await getRandomQuestion(mockReq(), res);
+    await getQuestionById(mockReq({ params: { id: '1' } }), res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({ error: 'No questions found' });
+    expect(res.json).toHaveBeenCalledWith({ error: 'Question not found' });
   });
 
   it('returns 500 on error', async () => {
     vi.mocked(supabase.from).mockReturnValueOnce({
-      select: vi.fn().mockResolvedValueOnce({ data: null, error: { message: 'DB error' } }),
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+        }),
+      }),
     } as any);
 
     const res = mockRes();
-    await getRandomQuestion(mockReq(), res);
+    await getQuestionById(mockReq({ params: { id: '1' } }), res);
 
     expect(res.status).toHaveBeenCalledWith(500);
   });
@@ -134,6 +147,20 @@ describe('getRandomQuestionByFilter', () => {
     await getRandomQuestionByFilter(req, res);
 
     expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 500 on error', async () => {
+    vi.mocked(supabase.from).mockReturnValueOnce({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      contains: vi.fn().mockResolvedValueOnce({ data: null, error: { message: 'DB error' } }),
+    } as any);
+
+    const req = mockReq({ params: { difficulty: 'easy', topic: 'Arrays' } });
+    const res = mockRes();
+    await getRandomQuestionByFilter(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
   });
 });
 
@@ -195,6 +222,20 @@ describe('updateQuestion', () => {
 
     expect(res.status).toHaveBeenCalledWith(404);
   });
+
+  it('returns 500 on error', async () => {
+    vi.mocked(supabase.from).mockReturnValueOnce({
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockResolvedValueOnce({ data: null, error: { message: 'DB error' } }),
+    } as any);
+
+    const req = mockReq({ params: { id: '1' }, body: { title: 'Updated' } });
+    const res = mockRes();
+    await updateQuestion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
 });
 
 describe('deleteQuestion', () => {
@@ -225,5 +266,19 @@ describe('deleteQuestion', () => {
     await deleteQuestion(req, res);
 
     expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 500 on error', async () => {
+    vi.mocked(supabase.from).mockReturnValueOnce({
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockResolvedValueOnce({ data: null, error: { message: 'DB error' } }),
+    } as any);
+
+    const req = mockReq({ params: { id: '1' } });
+    const res = mockRes();
+    await deleteQuestion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
   });
 });

--- a/services/question-service/src/tests/questionRoutes.test.ts
+++ b/services/question-service/src/tests/questionRoutes.test.ts
@@ -44,24 +44,32 @@ describe('GET /questions', () => {
   });
 });
 
-describe('GET /questions/random', () => {
-  it('returns a random question', async () => {
-    const questions = [{ id: '1' }, { id: '2' }];
+describe('GET /questions/:id', () => {
+  it('returns a question by its ID', async () => {
+    const question = { id: '1', title: 'Two Sum' };
     vi.mocked(supabase.from).mockReturnValueOnce({
-      select: vi.fn().mockResolvedValueOnce({ data: questions, error: null }),
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: question, error: null }),
+        }),
+      }),
     } as any);
 
-    const res = await request(app).get('/questions/random');
+    const res = await request(app).get('/questions/1');
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('id');
+    expect(res.body).toEqual(question);
   });
 
   it('returns 404 when no questions exist', async () => {
     vi.mocked(supabase.from).mockReturnValueOnce({
-      select: vi.fn().mockResolvedValueOnce({ data: [], error: null }),
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        }),
+      }),
     } as any);
 
-    const res = await request(app).get('/questions/random');
+    const res = await request(app).get('/questions/99999');
     expect(res.status).toBe(404);
   });
 });

--- a/services/user-service/src/controllers/userController.ts
+++ b/services/user-service/src/controllers/userController.ts
@@ -25,7 +25,11 @@ export class UserController {
     try {
       const { userId } = req.params;
 
-      const { data, error } = await supabase.from('profiles').select('display_name').eq('id', userId).single();
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('display_name')
+        .eq('id', userId)
+        .single();
 
       if (error) throw error;
 

--- a/services/user-service/src/controllers/userController.ts
+++ b/services/user-service/src/controllers/userController.ts
@@ -20,4 +20,19 @@ export class UserController {
       res.status(500).json({ error: err.message });
     }
   }
+
+  static async getNameById(req: Request, res: Response) {
+    try {
+      const { userId } = req.params;
+
+      const { data, error } = await supabase.from('profiles').select('display_name').eq('id', userId).single();
+
+      if (error) throw error;
+
+      res.json({ name: data.display_name });
+    } catch (err: any) {
+      console.error('Server error:', err);
+      res.status(500).json({ error: err.message });
+    }
+  }
 }

--- a/services/user-service/src/routes/userRoutes.ts
+++ b/services/user-service/src/routes/userRoutes.ts
@@ -7,6 +7,7 @@ const router = Router();
 
 router.get('/health', UserController.healthCheck);
 router.get('/profile', UserController.getProfile);
+router.get('/profile/:userId', UserController.getNameById);
 router.post('/:id/admin-request', RequestController.requestAdmin);
 router.get('/admin-requests', authenticate('developer'), RequestController.getAdminRequests);
 router.patch(

--- a/services/user-service/tests/userController.test.ts
+++ b/services/user-service/tests/userController.test.ts
@@ -85,4 +85,63 @@ describe('UserController', () => {
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: expect.any(String) }));
     });
   });
+
+  describe('getNameById', () => {
+    it('should return display name when user exists', async () => {
+      const req = { params: { userId: 'user-123' } } as any as Request;
+      const res = mockRes();
+
+      const single = vi.fn().mockResolvedValue({
+        data: { display_name: 'Alice' },
+        error: null,
+      });
+      const eq = vi.fn().mockReturnValue({ single });
+      const select = vi.fn().mockReturnValue({ eq });
+      (supabase.from as any).mockReturnValue({ select });
+
+      await UserController.getNameById(req, res);
+
+      expect(supabase.from).toHaveBeenCalledWith('profiles');
+      expect(select).toHaveBeenCalledWith('display_name');
+      expect(eq).toHaveBeenCalledWith('id', 'user-123');
+      expect(res.json).toHaveBeenCalledWith({ name: 'Alice' });
+    });
+
+    it('should return 500 when supabase returns an error', async () => {
+      const req = { params: { userId: 'user-123' } } as any as Request;
+      const res = mockRes();
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const single = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'Query failed' },
+      });
+      const eq = vi.fn().mockReturnValue({ single });
+      const select = vi.fn().mockReturnValue({ eq });
+      (supabase.from as any).mockReturnValue({ select });
+
+      await UserController.getNameById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Query failed' });
+    });
+
+    it('should return 500 when userId param is missing', async () => {
+      const req = { params: {} } as any as Request;
+      const res = mockRes();
+      vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const single = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'invalid input' },
+      });
+      const eq = vi.fn().mockReturnValue({ single });
+      const select = vi.fn().mockReturnValue({ eq });
+      (supabase.from as any).mockReturnValue({ select });
+
+      await UserController.getNameById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
 });

--- a/services/user-service/tests/userRoutes.test.ts
+++ b/services/user-service/tests/userRoutes.test.ts
@@ -7,7 +7,7 @@ vi.mock('../src/middleware/authMiddleware', () => ({
 }));
 
 vi.mock('../src/controllers/userController', () => ({
-  UserController: { 
+  UserController: {
     healthCheck: vi.fn(),
     getProfile: vi.fn(),
     getNameById: vi.fn(),

--- a/services/user-service/tests/userRoutes.test.ts
+++ b/services/user-service/tests/userRoutes.test.ts
@@ -7,7 +7,11 @@ vi.mock('../src/middleware/authMiddleware', () => ({
 }));
 
 vi.mock('../src/controllers/userController', () => ({
-  UserController: { healthCheck: vi.fn(), getProfile: vi.fn() },
+  UserController: { 
+    healthCheck: vi.fn(),
+    getProfile: vi.fn(),
+    getNameById: vi.fn(),
+  },
 }));
 
 vi.mock('../src/controllers/requestController', () => ({


### PR DESCRIPTION
## Summary
Users can now view their past question attempt history from a dedicated History page. Each entry shows the question title, difficulty, topic tags, timestamp, peer partner, and the submitted solution.

## Changes

### Frontend
- Added `History` page with attempt list and expandable solution view per entry

### Question Service
- Added `getQuestionById` endpoint to retrieve question details for history enrichment
- Added unit tests covering success, not found, and database error cases

### User Service
- Added `getNameById` endpoint to resolve partner display names by user ID
- Added unit tests covering success, not found, and database error cases

## Approach
History rows are fetched directly from the Supabase history table, then enriched client-side by calling the question service and user service in parallel via `Promise.all` to resolve question details and partner display names respectively.