### PR TITLE
add CD pipeline for ECS and S3/CloudFront deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ['CI']
     types: [completed]
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,3 +68,43 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/${{ matrix.service }}:${{ github.sha }}
+
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_USER_SERVICE_URL: ${{ secrets.VITE_USER_SERVICE_URL }}
+          VITE_QUESTION_SERVICE_URL: ${{ secrets.VITE_QUESTION_SERVICE_URL }}
+          VITE_MATCHING_WS_URL: ${{ secrets.VITE_MATCHING_WS_URL }}
+          VITE_COLLAB_WS_URL: ${{ secrets.VITE_COLLAB_WS_URL }}
+
+      - name: Upload frontend build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -240,3 +240,30 @@ jobs:
           service: peerprep-collaboration-service
           cluster: ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
+
+  deploy-frontend:
+    name: Deploy Frontend
+    runs-on: ubuntu-latest
+    needs: build-frontend
+
+    steps:
+      - name: Download frontend build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: dist
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload to S3
+        run: aws s3 sync dist/ s3://peerprep-frontend --delete
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,3 +108,135 @@ jobs:
           name: frontend-dist
           path: frontend/dist
           retention-days: 1
+
+  deploy-backend:
+    name: Deploy Backend
+    runs-on: ubuntu-latest
+    needs: build-backend
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ── nginx ──────────────────────────────────────────
+      - name: Fetch nginx task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition peerprep-nginx \
+            --query taskDefinition \
+            > nginx-task-def.json
+
+      - name: Render nginx image
+        id: render-nginx
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: nginx-task-def.json
+          container-name: nginx
+          image: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/nginx:${{ github.sha }}
+
+      - name: Deploy nginx
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-nginx.outputs.task-definition }}
+          service: peerprep-nginx
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      # ── user-service ───────────────────────────────────
+      - name: Fetch user-service task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition peerprep-user-service \
+            --query taskDefinition \
+            > user-service-task-def.json
+
+      - name: Render user-service image
+        id: render-user-service
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: user-service-task-def.json
+          container-name: user-service
+          image: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/user-service:${{ github.sha }}
+
+      - name: Deploy user-service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-user-service.outputs.task-definition }}
+          service: peerprep-user-service
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      # ── question-service ───────────────────────────────
+      - name: Fetch question-service task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition peerprep-question-service \
+            --query taskDefinition \
+            > question-service-task-def.json
+
+      - name: Render question-service image
+        id: render-question-service
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: question-service-task-def.json
+          container-name: question-service
+          image: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/question-service:${{ github.sha }}
+
+      - name: Deploy question-service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-question-service.outputs.task-definition }}
+          service: peerprep-question-service
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      # ── matching-service ───────────────────────────────
+      - name: Fetch matching-service task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition peerprep-matching-service \
+            --query taskDefinition \
+            > matching-service-task-def.json
+
+      - name: Render matching-service image
+        id: render-matching-service
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: matching-service-task-def.json
+          container-name: matching-service
+          image: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/matching-service:${{ github.sha }}
+
+      - name: Deploy matching-service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-matching-service.outputs.task-definition }}
+          service: peerprep-matching-service
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      # ── collaboration-service ──────────────────────────
+      - name: Fetch collaboration-service task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition peerprep-collaboration-service \
+            --query taskDefinition \
+            > collaboration-service-task-def.json
+
+      - name: Render collaboration-service image
+        id: render-collaboration-service
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: collaboration-service-task-def.json
+          container-name: collaboration-service
+          image: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/collaboration-service:${{ github.sha }}
+
+      - name: Deploy collaboration-service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-collaboration-service.outputs.task-definition }}
+          service: peerprep-collaboration-service
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,3 +19,52 @@ env:
   AWS_REGION: ${{ vars.AWS_REGION }}
   AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
   ECS_CLUSTER: peerprep
+
+jobs:
+  build-backend:
+    name: Build ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: user-service
+            context: services/user-service
+            dockerfile: services/user-service/Dockerfile
+          - service: question-service
+            context: services/question-service
+            dockerfile: services/question-service/Dockerfile
+          - service: matching-service
+            context: .
+            dockerfile: services/matching-service/Dockerfile
+          - service: collaboration-service
+            context: services/collaboration-service
+            dockerfile: services/collaboration-service/Dockerfile
+          - service: nginx
+            context: nginx
+            dockerfile: nginx/Dockerfile
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com/peerprep/${{ matrix.service }}:${{ github.sha }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,21 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: cd-production
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+  ECS_CLUSTER: peerprep

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -354,25 +354,135 @@ This verifies that each deployable backend image can be built successfully from 
 
 ## CD Pipeline
 
-The CD pipeline is not yet implemented in the repository. The deployment flow is structured as follows.
+The CD pipeline is defined in [`.github/workflows/cd.yml`](../.github/workflows/cd.yml).
+
+### Trigger
+
+The workflow runs in two modes:
+
+- automatically after the CI workflow completes successfully on `main`
+- manually via workflow dispatch in the GitHub Actions UI
+
+The automatic trigger uses `workflow_run` to chain CI and CD. The workflow checks that CI concluded successfully before proceeding. Manual dispatch bypasses this check for re-deploys.
+
+A concurrency group (`cd-production`) prevents overlapping deploys. If a second deploy is triggered while one is running, it queues rather than cancels the in-progress deploy.
+
+### Authentication
+
+The workflow authenticates with AWS using OIDC federation. GitHub Actions assumes an IAM role directly without stored long-lived credentials.
+
+Required permissions:
+
+- `id-token: write` for OIDC token exchange
+- `contents: read` for repository checkout
+
+### Job structure
+
+The workflow has four jobs:
+
+```
+build-backend ──> deploy-backend
+                                   (independent)
+build-frontend ─> deploy-frontend
+```
+
+The two build jobs run in parallel. Each deploy job runs after its corresponding build job completes.
 
 ### Backend CD flow
 
-1. Build production images for:
-   - `user-service`
-   - `question-service`
-   - `matching-service`
-   - `collaboration-service`
-   - `nginx`
-2. Push images to ECR.
-3. Update ECS task definitions with the new image tags.
-4. Roll the ECS services forward and wait for service stability.
+#### Build phase
+
+The `build-backend` job builds all five container images in parallel using a matrix strategy:
+
+| Service                | Docker context              | Dockerfile                             |
+| ---------------------- | --------------------------- | -------------------------------------- |
+| `user-service`         | `services/user-service`     | `services/user-service/Dockerfile`     |
+| `question-service`     | `services/question-service` | `services/question-service/Dockerfile` |
+| `matching-service`     | `.` (repo root)             | `services/matching-service/Dockerfile` |
+| `collaboration-service`| `services/collaboration-service` | `services/collaboration-service/Dockerfile` |
+| `nginx`                | `nginx`                     | `nginx/Dockerfile`                     |
+
+`matching-service` uses the repository root as its Docker context because its Dockerfile copies shared modules from the `shared/` directory.
+
+Each image is tagged with the git commit SHA and pushed to ECR:
+
+```
+<account-id>.dkr.ecr.<region>.amazonaws.com/peerprep/<service>:<git-sha>
+```
+
+#### Deploy phase
+
+The `deploy-backend` job deploys all five ECS services sequentially in this order:
+
+1. `nginx`
+2. `user-service`
+3. `question-service`
+4. `matching-service`
+5. `collaboration-service`
+
+Infrastructure goes first, then stateless services, then services with Redis and RabbitMQ dependencies.
+
+For each service, the deploy:
+
+1. Fetches the current ECS task definition
+2. Renders a new task definition revision with the updated image tag
+3. Registers the new task definition and updates the ECS service
+4. Waits for ECS service stability before proceeding to the next service
 
 ### Frontend CD flow
 
-1. Build the frontend with production `VITE_*` configuration.
-2. Upload the generated assets to S3.
-3. Invalidate the CloudFront cache so the new frontend is served immediately.
+#### Build phase
+
+The `build-frontend` job:
+
+1. Checks out the repository
+2. Sets up Node 24
+3. Installs dependencies with `npm ci`
+4. Builds the frontend with production `VITE_*` environment variables injected from GitHub secrets
+5. Uploads the `frontend/dist/` output as a workflow artifact
+
+#### Deploy phase
+
+The `deploy-frontend` job:
+
+1. Downloads the build artifact
+2. Syncs the assets to S3 with `aws s3 sync --delete`
+3. Invalidates the CloudFront cache with path `/*`
+
+The `--delete` flag removes stale assets from S3 that are no longer part of the build output.
+
+### GitHub configuration
+
+The following must be configured in the repository's GitHub settings.
+
+#### Secrets
+
+| Secret                       | Purpose                                    |
+| ---------------------------- | ------------------------------------------ |
+| `AWS_ROLE_ARN`               | IAM role for OIDC federation               |
+| `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution for cache invalidation |
+| `VITE_SUPABASE_URL`          | Frontend build-time Supabase URL           |
+| `VITE_SUPABASE_ANON_KEY`     | Frontend build-time Supabase anon key      |
+| `VITE_USER_SERVICE_URL`      | Frontend build-time user service URL       |
+| `VITE_QUESTION_SERVICE_URL`  | Frontend build-time question service URL   |
+| `VITE_MATCHING_WS_URL`       | Frontend build-time matching WebSocket URL |
+| `VITE_COLLAB_WS_URL`         | Frontend build-time collab WebSocket URL   |
+
+#### Variables
+
+| Variable         | Purpose              |
+| ---------------- | -------------------- |
+| `AWS_REGION`     | AWS region            |
+| `AWS_ACCOUNT_ID` | AWS account number    |
+
+### AWS resource naming
+
+The workflow uses the following provisional resource names. These are defined in the workflow's top-level `env` block and can be updated to match the actual infrastructure.
+
+- ECR repositories: `peerprep/user-service`, `peerprep/question-service`, `peerprep/matching-service`, `peerprep/collaboration-service`, `peerprep/nginx`
+- ECS cluster: `peerprep`
+- ECS services: `peerprep-user-service`, `peerprep-question-service`, `peerprep-matching-service`, `peerprep-collaboration-service`, `peerprep-nginx`
+- S3 bucket: `peerprep-frontend`
 
 ### Platform requirements for CD
 
@@ -382,7 +492,7 @@ The CD workflow depends on:
 - an ECS cluster and ECS services
 - an S3 bucket for frontend assets
 - a CloudFront distribution
-- IAM permissions for GitHub Actions
+- an IAM role with an OIDC trust policy scoped to this repository
 - external Redis, RabbitMQ, and Supabase endpoints available to the runtime services
 
 ## Operational Summary

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -394,13 +394,13 @@ The two build jobs run in parallel. Each deploy job runs after its corresponding
 
 The `build-backend` job builds all five container images in parallel using a matrix strategy:
 
-| Service                | Docker context              | Dockerfile                             |
-| ---------------------- | --------------------------- | -------------------------------------- |
-| `user-service`         | `services/user-service`     | `services/user-service/Dockerfile`     |
-| `question-service`     | `services/question-service` | `services/question-service/Dockerfile` |
-| `matching-service`     | `.` (repo root)             | `services/matching-service/Dockerfile` |
-| `collaboration-service`| `services/collaboration-service` | `services/collaboration-service/Dockerfile` |
-| `nginx`                | `nginx`                     | `nginx/Dockerfile`                     |
+| Service                 | Docker context                   | Dockerfile                                  |
+| ----------------------- | -------------------------------- | ------------------------------------------- |
+| `user-service`          | `services/user-service`          | `services/user-service/Dockerfile`          |
+| `question-service`      | `services/question-service`      | `services/question-service/Dockerfile`      |
+| `matching-service`      | `.` (repo root)                  | `services/matching-service/Dockerfile`      |
+| `collaboration-service` | `services/collaboration-service` | `services/collaboration-service/Dockerfile` |
+| `nginx`                 | `nginx`                          | `nginx/Dockerfile`                          |
 
 `matching-service` uses the repository root as its Docker context because its Dockerfile copies shared modules from the `shared/` directory.
 
@@ -457,23 +457,23 @@ The following must be configured in the repository's GitHub settings.
 
 #### Secrets
 
-| Secret                       | Purpose                                    |
-| ---------------------------- | ------------------------------------------ |
-| `AWS_ROLE_ARN`               | IAM role for OIDC federation               |
+| Secret                       | Purpose                                        |
+| ---------------------------- | ---------------------------------------------- |
+| `AWS_ROLE_ARN`               | IAM role for OIDC federation                   |
 | `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront distribution for cache invalidation |
-| `VITE_SUPABASE_URL`          | Frontend build-time Supabase URL           |
-| `VITE_SUPABASE_ANON_KEY`     | Frontend build-time Supabase anon key      |
-| `VITE_USER_SERVICE_URL`      | Frontend build-time user service URL       |
-| `VITE_QUESTION_SERVICE_URL`  | Frontend build-time question service URL   |
-| `VITE_MATCHING_WS_URL`       | Frontend build-time matching WebSocket URL |
-| `VITE_COLLAB_WS_URL`         | Frontend build-time collab WebSocket URL   |
+| `VITE_SUPABASE_URL`          | Frontend build-time Supabase URL               |
+| `VITE_SUPABASE_ANON_KEY`     | Frontend build-time Supabase anon key          |
+| `VITE_USER_SERVICE_URL`      | Frontend build-time user service URL           |
+| `VITE_QUESTION_SERVICE_URL`  | Frontend build-time question service URL       |
+| `VITE_MATCHING_WS_URL`       | Frontend build-time matching WebSocket URL     |
+| `VITE_COLLAB_WS_URL`         | Frontend build-time collab WebSocket URL       |
 
 #### Variables
 
-| Variable         | Purpose              |
-| ---------------- | -------------------- |
-| `AWS_REGION`     | AWS region            |
-| `AWS_ACCOUNT_ID` | AWS account number    |
+| Variable         | Purpose            |
+| ---------------- | ------------------ |
+| `AWS_REGION`     | AWS region         |
+| `AWS_ACCOUNT_ID` | AWS account number |
 
 ### AWS resource naming
 


### PR DESCRIPTION
## Summary

- Add GitHub Actions CD workflow (`.github/workflows/cd.yml`) that deploys backend services to ECS Fargate and frontend assets to S3/CloudFront
- Update deployment guide with full CD pipeline documentation

## Workflow structure

The CD workflow triggers automatically after CI passes on `main`, or manually via workflow dispatch. It uses OIDC for AWS authentication (no stored credentials) and queues overlapping deploys.

Four jobs run in two parallel tracks:

```
build-backend ──> deploy-backend
build-frontend ─> deploy-frontend
```

**Backend**: builds 5 Docker images in parallel (user-service, question-service, matching-service, collaboration-service, nginx), pushes to ECR with git SHA tags, then deploys to ECS sequentially with stability waits.

**Frontend**: builds Vite app with production `VITE_*` env vars, syncs to S3, invalidates CloudFront.

## Prerequisites before this workflow can run

The following must be configured by the DevOps team:

- GitHub secrets: `AWS_ROLE_ARN`, `CLOUDFRONT_DISTRIBUTION_ID`, and 6 `VITE_*` vars
- GitHub variables: `AWS_REGION`, `AWS_ACCOUNT_ID`
- AWS resources: ECR repos, ECS cluster/services, S3 bucket, CloudFront distribution, IAM OIDC trust policy
- Resource naming conventions are provisional — defined in the workflow `env` block for easy adjustment

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Confirm `workflow_run` references the correct CI workflow name (`"CI"`)
- [ ] Confirm matrix entries match existing Dockerfiles and contexts
- [ ] Confirm all required GitHub secrets/variables are documented
- [ ] End-to-end test after AWS infrastructure is provisioned