### PR TITLE
fix: handle matching errors and improve timeout retry UX

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,11 +2,11 @@
 set -e
 
 echo "=== Format check ==="
-npm run format
-git add -A
+npm run format:check
 
 echo "=== Tests ==="
 cd services/user-service && npm test && cd ../..
 cd services/question-service && npm test && cd ../..
+cd services/matching-service && npm test && cd ../..
 
 echo "=== All checks passed ==="

--- a/frontend/src/pages/Queue.tsx
+++ b/frontend/src/pages/Queue.tsx
@@ -79,8 +79,17 @@ const Queue = () => {
   };
 
   const handleRetry = () => {
-    resetMatching();
-    navigate('/match');
+    if (!user || !selectedDifficulty || !selectedTopic || !selectedLanguage) {
+      navigate('/match');
+      return;
+    }
+    setPhase('queue');
+    joinQueue({
+      userId: user.id,
+      difficulty: selectedDifficulty,
+      topics: [selectedTopic],
+      language: selectedLanguage,
+    });
   };
 
   const handleChangePreferences = () => {
@@ -138,10 +147,10 @@ const Queue = () => {
               Try changing your preferences or retry with the same settings.
             </p>
             <div className="flex gap-3 justify-center">
-              <Button variant="hero" onClick={handleChangePreferences}>
-                Change Preferences
+              <Button variant="ghost" onClick={handleChangePreferences}>
+                Cancel
               </Button>
-              <Button variant="ghost" onClick={handleRetry}>
+              <Button variant="hero" onClick={handleRetry}>
                 Retry
               </Button>
             </div>

--- a/frontend/src/pages/Queue.tsx
+++ b/frontend/src/pages/Queue.tsx
@@ -21,7 +21,6 @@ const Queue = () => {
     pendingSession,
     setCurrentState,
     clearPendingSession,
-    resetMatching,
   } = useAppStore();
 
   const { joinQueue, cancelQueue, status, matchData, error, timeLeft } = useMatchmaking();

--- a/frontend/src/pages/Session.tsx
+++ b/frontend/src/pages/Session.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { CollaborativeMonacoEditor } from '@/components/CollaborativeMonacoEditor';
+import { ConfirmModal } from '@/components/ui/ConfirmModal';
 import { useAuth } from '@/contexts/AuthContext';
 import { useCollabSession } from '@/hooks/useCollabSession';
 import { cn } from '@/lib/utils';
@@ -142,6 +143,8 @@ const Session = () => {
   const { user } = useAuth();
   const { pendingSession, collabSessionStatus, collabError, setCurrentState, clearPendingSession } =
     useAppStore();
+  const [showBackConfirmModal, setShowBackConfirmModal] = useState(false);
+  const allowNavigationRef = useRef(false);
 
   const { sharedDoc, joinedSession, participantStatuses, sessionEnded, leaveSession } =
     useCollabSession(pendingSession);
@@ -175,6 +178,24 @@ const Session = () => {
     return () => window.clearTimeout(timeoutId);
   }, [clearPendingSession, navigate, sessionEnded]);
 
+  useEffect(() => {
+    const handlePopState = () => {
+      if (allowNavigationRef.current) {
+        return;
+      }
+
+      setShowBackConfirmModal(true);
+      window.history.pushState(null, '', window.location.href);
+    };
+
+    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
   const participantIds = Array.from(
     new Set(
       [
@@ -193,6 +214,15 @@ const Session = () => {
     leaveSession();
     clearPendingSession();
     navigate('/match', { replace: true });
+  };
+
+  const handleBackConfirm = () => {
+    allowNavigationRef.current = true;
+    setShowBackConfirmModal(false);
+    leaveSession();
+    clearPendingSession();
+    setCurrentState('queue');
+    navigate('/queue', { replace: true });
   };
 
   const connection = getConnectionPresentation(
@@ -375,6 +405,17 @@ const Session = () => {
           </div>
         </div>
       </main>
+
+      <ConfirmModal
+        isOpen={showBackConfirmModal}
+        title="Leave session?"
+        description="If you press back, you will be rejoining the queue. Are you sure you want to continue?"
+        confirmLabel="Continue"
+        cancelLabel="Stay in session"
+        variant="danger"
+        onConfirm={handleBackConfirm}
+        onCancel={() => setShowBackConfirmModal(false)}
+      />
     </div>
   );
 };

--- a/services/matching-service/src/services/matchmaking.ts
+++ b/services/matching-service/src/services/matchmaking.ts
@@ -68,6 +68,12 @@ export async function findMatch(user: User): Promise<Match | undefined> {
         `Match ${match.id} created: ${user.id} <-> ${candidate.id} | topic: ${commonTopic}`,
       );
       return match;
+    } catch (error) {
+      logger.error(
+        `Failed to create match between ${user.id} and ${candidate.id} (topic: ${commonTopic}):`,
+        error,
+      );
+      continue;
     } finally {
       // always release both locks, whether match succeeded or an error occurred
       await releaseUserMatch(user.id);

--- a/services/matching-service/tests/matching.e2e.test.ts
+++ b/services/matching-service/tests/matching.e2e.test.ts
@@ -20,6 +20,7 @@ vi.mock('../src/services/questionService', () => ({
 import { TestServer, startTestServer, flushRedis } from './helpers/server';
 import { createConnectedClient, waitForEvent, disconnectAll } from './helpers/client';
 import { publishEvent } from '../src/config/rabbitmq';
+import { getRandomQuestion } from '../src/services/questionService';
 import { redis } from '../src/config/redis';
 import { Socket } from 'socket.io-client';
 
@@ -247,5 +248,48 @@ describe('Group B: Edge Cases', () => {
 
     const error = await errorPromise;
     expect(error.message).toContain('Missing required fields');
+  });
+
+  it('should keep users in queue when question service fails', async () => {
+    // Make getRandomQuestion throw to simulate no questions for this filter
+    vi.mocked(getRandomQuestion).mockRejectedValueOnce(
+      new Error('Failed to get random question: 404'),
+    );
+
+    const client1 = await createConnectedClient(server.port);
+    const client2 = await createConnectedClient(server.port);
+
+    let matched = false;
+    client1.on('match_found', () => {
+      matched = true;
+    });
+    client2.on('match_found', () => {
+      matched = true;
+    });
+
+    client1.emit('join_queue', {
+      userId: 'user-qfail-1',
+      difficulty: 'easy',
+      topics: ['arrays'],
+      language: 'javascript',
+    });
+
+    client2.emit('join_queue', {
+      userId: 'user-qfail-2',
+      difficulty: 'easy',
+      topics: ['arrays'],
+      language: 'javascript',
+    });
+
+    // Wait for the eager match attempt to process
+    await new Promise((r) => setTimeout(r, 1000));
+
+    // No match should have been created
+    expect(matched).toBe(false);
+
+    // Both users should still be in the queue
+    const members = await redis.zRange('queue:easy:javascript', 0, -1);
+    expect(members).toContain('user-qfail-1');
+    expect(members).toContain('user-qfail-2');
   });
 });


### PR DESCRIPTION
## Summary
- Handle question service errors (e.g., no questions for a difficulty/topic combo) gracefully in the matching loop — errors are caught and logged instead of crashing `findMatch()`, allowing the loop to continue to the next candidate
- Fix timeout retry button to re-queue with the same preferences instead of navigating away and clearing selections. Rename "Change Preferences" to "Cancel" and swap button emphasis so Retry is the primary action

## Test plan
- [ ] Join queue with a difficulty/topic that has no questions in the database → verify matching service logs the error and users stay in queue until timeout (no crash)
- [ ] Join queue, wait for timeout, click "Retry" → verify you stay on `/queue` and re-enter the queue with the same preferences
- [ ] Join queue, wait for timeout, click "Cancel" → verify you navigate to `/match` (question select page)
- [ ] Join queue, get matched normally → verify happy path still works